### PR TITLE
Rework collision detection

### DIFF
--- a/IsoRTS/collision.cpp
+++ b/IsoRTS/collision.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include "Collision.h"
 #include <iostream>
+#include "globalFunctions.h"
 
 namespace Collision
 {
@@ -58,13 +59,29 @@ namespace Collision
 
 	BitmaskManager Bitmasks;
 
+	bool singlePixelTest(const sf::Sprite& Object1, sf::Vector2f& mousePosition, sf::Uint8 AlphaLimit) {
+		if (Object1.getGlobalBounds().contains(mousePosition.x, mousePosition.y)) {
+			sf::IntRect O1SubRect = Object1.getTextureRect();
+			sf::Uint8* mask1 = Bitmasks.GetMask(Object1.getTexture());
+
+			sf::Vector2f o1v = Object1.getInverseTransform().transformPoint(mousePosition.x, mousePosition.y);
+			// Make sure pixels fall within the sprite's subrect
+			if (o1v.x > 0 && o1v.y > 0 && o1v.x < O1SubRect.width && o1v.y < O1SubRect.height) {
+				if (Bitmasks.GetPixel(mask1, Object1.getTexture(), (int)(o1v.x) + O1SubRect.left, (int)(o1v.y) + O1SubRect.top) > AlphaLimit) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
 	bool PixelPerfectTest(const sf::Sprite& Object1, const sf::Sprite& Object2, sf::Uint8 AlphaLimit) {
 		sf::FloatRect Intersection;
-		//std::cout << Object1.getPosition().x << " - " << Object1.getPosition().y << " O2:" << Object2.getPosition().x << " - " << Object2.getPosition().y << std::endl;
+		std::cout << "trying to collide: O1:" << Object1.getPosition().x << " - " << Object1.getPosition().y << " O2:" << Object2.getPosition().x << " - " << Object2.getPosition().y << std::endl;
 		if (Object1.getGlobalBounds().intersects(Object2.getGlobalBounds(), Intersection)) {
 			sf::IntRect O1SubRect = Object1.getTextureRect();
 			sf::IntRect O2SubRect = Object2.getTextureRect();
-
+			std::cout << std::endl << std::endl << std::endl << "!!there is overlap lets see if it is pixel perfect!!" << std::endl << std::endl << std::endl;
 			sf::Uint8* mask1 = Bitmasks.GetMask(Object1.getTexture());
 			sf::Uint8* mask2 = Bitmasks.GetMask(Object2.getTexture());
 
@@ -190,3 +207,4 @@ namespace Collision
 		return true;
 	}
 }
+

--- a/IsoRTS/collision.h
+++ b/IsoRTS/collision.h
@@ -38,6 +38,19 @@ it freely, subject to the following restrictions:
 
 
 namespace Collision {
+
+	///////
+	/// Test if a single pixel collides By testing the alpha value at the given location.
+	/// Supports scaling and rotation
+	/// AlphaLimit: The threshold at which a pixel becomes "solid". If AlphaLimit is 127, a pixel with
+	/// alpha value 128 will cause a collision and a pixel with alpha value 126 will not.
+	/// 
+	/// This functions creates bitmasks of the textures of the sprite by
+	/// downloading the textures from the graphics card to memory -> SLOW!
+	/// You can avoid this by using the "CreateTextureAndBitmask" function
+	//////
+	bool singlePixelTest(const sf::Sprite& Object1, sf::Vector2f& mousePosition, sf::Uint8 AlphaLimit);
+
 	//////
 	/// Test for a collision between two sprites by comparing the alpha values of overlapping pixels
 	/// Supports scaling and rotation
@@ -49,6 +62,7 @@ namespace Collision {
 	/// You can avoid this by using the "CreateTextureAndBitmask" function
 	//////
 	bool PixelPerfectTest(const sf::Sprite& Object1, const sf::Sprite& Object2, sf::Uint8 AlphaLimit = 0);
+
 
 	//////
 	/// Replaces Texture::loadFromFile

--- a/IsoRTS/gamestate.cpp
+++ b/IsoRTS/gamestate.cpp
@@ -829,28 +829,44 @@ void gameState::clickToSelectObjectOrBuilding()
 {
     this->objectSelectedId = -1;
     this->buildingSelectedId = -1;
-    sf::IntRect selection = sf::IntRect(mousePosition.x, mousePosition.y, 1, 1);
-    this->spriteMouseCord.setPosition(mousePosition.x, mousePosition.y);
+    //sf::IntRect selection = sf::IntRect(mousePosition.x, mousePosition.y, 1, 1);
+    this->spriteMouseCord.setPosition(static_cast<float>(round(mousePosition.x)), static_cast<float>(round(mousePosition.y)));
 
     if (listOfBuildings.size() > 0) {
         //Check if a bulding is clicked
         for (const buildings& building : listOfBuildings) {
             listOfBuildingTemplates[building.getType()].setSpritePosition(worldSpace(building.getLocation()));
-            if (Collision::PixelPerfectTest(listOfBuildingTemplates[building.getType()].getBuildingSprite(), this->spriteMouseCord, 128)) {
+            //using a pixel cord
+            if (Collision::singlePixelTest(listOfBuildingTemplates[building.getType()].getBuildingSprite(), mousePosition, 128)) {
                 this->buildingSelectedId = building.getBuildingId();
             }
+
+
+
+            /*/if (Collision::PixelPerfectTest(listOfBuildingTemplates[building.getType()].getBuildingSprite(), this->spriteMouseCord, 128)) {
+                this->buildingSelectedId = building.getBuildingId();
+            }
+            */
+
         }
     }
       
     if (listOfObjects.size() > 0) {
         int highestTop = 0;
         for (const objects& object : listOfObjects) {
-            sf::IntRect result;
             listOfObjectTemplates[static_cast<uint32_t>(object.getType())].setPosition(worldSpace(object.getLocation()));
-            if (Collision::PixelPerfectTest(listOfObjectTemplates[static_cast<uint32_t>(object.getType())].getSprite(), this->spriteMouseCord, 128)) {
+            //using a pixel cord
+            if (Collision::singlePixelTest(listOfObjectTemplates[static_cast<uint32_t>(object.getType())].getSprite(), mousePosition, 128)) {
                 this->objectSelectedId = object.getObjectId();
             }
+
+            /*Using a sprite            
+            if (Collision::PixelPerfectTest(listOfObjectTemplates[static_cast<uint32_t>(object.getType())].getSprite(), this->spriteMouseCord, 128)) {
+                this->objectSelectedId = object.getObjectId();
+            }*/
+
             /* Old style detection
+            sf::IntRect result;
             if (selection.intersects(object.getLastIntRect(), result)) {
                 if (object.getLastIntRect().top > highestTop) {
                     this->objectSelectedId = object.getObjectId();
@@ -948,12 +964,21 @@ void gameState::getDefinitiveSelection()
             }
             else {
                 //One coordinate was clicked find actor there we will be pixel perfect!
-                this->spriteMouseCord.setPosition(mousePosition.x, mousePosition.y);
+
+                //using a pixel cord
+                //this->spriteMouseCord.setPosition(mousePosition.x, mousePosition.y);
+                
                 for (const actors& actor : listOfActors) {
                     listOfActorTemplates[actor.getType()].setSpritePosition(worldSpace(actor.getActorCords()));
+                    if (Collision::singlePixelTest(listOfActorTemplates[actor.getType()].getActorSprite(), mousePosition, 128)) {
+                        selectedUnits.push_back({ actor.getActorId() });
+                    }
+
+                    /* using a mouse sprite which was buggy
                     if (Collision::PixelPerfectTest(listOfActorTemplates[actor.getType()].getActorSprite(), this->spriteMouseCord, 128)) {
                         selectedUnits.push_back({ actor.getActorId() });
                     }
+                    */
                 }
             }
         }


### PR DESCRIPTION
Uses a single set of cords rather then a 'mouse' sprite to detect collision.